### PR TITLE
Add WAPURBot Autonomous mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,10 @@
 
 # Package Files #
 *.jar
-!json.jar
-!json-sources.jar
 *.war
 *.ear
+/build/
+/dist/
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/build.properties
+++ b/build.properties
@@ -4,4 +4,4 @@ robot.class=${package}.Robot
 simulation.world.file=/usr/share/frcsim/worlds/GearsBotDemo.world
 team-number=1076
 #Uncomment and point at user libraries to include them in the build. Do not put libraries in the \wpilib\java folder, this folder is completely overwritten on plugin update.
-#userLibs=${user.home}/wpilib/user/lib
+userLibs=${basedir}/json.jar

--- a/src/org/usfirst/frc/team1076/robot/Robot.java
+++ b/src/org/usfirst/frc/team1076/robot/Robot.java
@@ -32,9 +32,9 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 public class Robot extends IterativeRobot {
 	
 	final double DRIVE_SPEED_DEFAULT = 0.5;
-	final double DRIVE_TIME_DEFAULT = 2.0;
+	final double DRIVE_TIME_DEFAULT = 1.0;
 	final double LEFT_FACTOR_DEFAULT = 0.98;
-	final double TIME_FACTOR_DEFAULT = 0.05;
+	final double TIME_FACTOR_DEFAULT = 0.04;
 	final double TURN_SPEED_DEFAULT = 0.2;
 
     public static final String IP = "0.0.0.0";
@@ -91,7 +91,16 @@ public class Robot extends IterativeRobot {
 
     }
 	
+    int dbgCounter = 0;
 	public void disabledPeriodic() {
+		if (dbgCounter++ % 50 == 0) {
+			visionReceiver.receive();
+			System.out.println(
+					"status: " + visionReceiver.getData().getStatus() +
+					", heading: " + visionReceiver.getData().getHeading() +
+					", range: " + visionReceiver.getData().getRange() +
+					", errors: " + visionReceiver.getData().getErrorCount());
+		}
 		Scheduler.getInstance().run();
 	}
 

--- a/src/org/usfirst/frc/team1076/robot/Robot.java
+++ b/src/org/usfirst/frc/team1076/robot/Robot.java
@@ -30,6 +30,16 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
  * directory.
  */
 public class Robot extends IterativeRobot {
+	
+	final double DRIVE_SPEED_DEFAULT = 0.5;
+	final double DRIVE_TIME_DEFAULT = 2.0;
+	final double LEFT_FACTOR_DEFAULT = 0.98;
+	final double TIME_FACTOR_DEFAULT = 0.05;
+	final double TURN_SPEED_DEFAULT = 0.2;
+
+    public static final String IP = "0.0.0.0";
+    public static final int VISION_PORT = 5880;
+    public static final int SONAR_PORT = 5881;
 
 	public static OI oi;
 	Gamepad gamepad = new Gamepad(0);
@@ -40,17 +50,13 @@ public class Robot extends IterativeRobot {
 	LeftRightMotors leftRight = new LeftRightMotors(leftMotor, rightMotor);
 	FrontBackMotors frontBack = new FrontBackMotors(frontMotor, backMotor);
 	TeleopCommand teleopCommand = new TeleopCommand(gamepad, frontBack, leftRight);
-
+    
     Command autonomousCommand;
     Compressor compressor = new Compressor(0);
     DoorPneumatic door;
     VisionReceiver visionReceiver;
     SonarReceiver sonarReceiver;
     SonarTrigger sonarTrigger;
-
-    public static final String IP = "0.0.0.0";
-    public static final int VISION_PORT = 5880;
-    public static final int SONAR_PORT = 5881;
     
     /**
      * This function is run when the robot is first started up and should be
@@ -58,13 +64,15 @@ public class Robot extends IterativeRobot {
      */
     public void robotInit() {
         door = new DoorPneumatic(new Solenoid(0));
+        System.out.println(door);
 		oi = new OI(door);
 		gamepad = new Gamepad(0);
         compressor.start();
-        SmartDashboard.putNumber("Speed", 0.5);
-        SmartDashboard.putNumber("Time", 2);
-        SmartDashboard.putNumber("Left Factor", 1);
-        SmartDashboard.putNumber("Time Factor", 1);
+        SmartDashboard.putNumber("Speed", DRIVE_SPEED_DEFAULT);
+        SmartDashboard.putNumber("Time", DRIVE_TIME_DEFAULT);
+        SmartDashboard.putNumber("Left Factor", LEFT_FACTOR_DEFAULT);
+        SmartDashboard.putNumber("Time Factor", TIME_FACTOR_DEFAULT);
+        SmartDashboard.putNumber("Turn Speed", TURN_SPEED_DEFAULT);
         
         try {
             visionReceiver = new VisionReceiver(IP, VISION_PORT);
@@ -97,16 +105,17 @@ public class Robot extends IterativeRobot {
 	 * or additional comparisons to the switch structure below with additional strings & commands.
 	 */
     public void autonomousInit() {
-    	leftRight.leftFactor = SmartDashboard.getNumber("Left Factor", 1);
-    	double speed = SmartDashboard.getNumber("Speed", 0.5);
-    	double time = SmartDashboard.getNumber("Time", 2);
-    	double turnFactor = SmartDashboard.getNumber("Time Factor", 1);
+    	leftRight.leftFactor = SmartDashboard.getNumber("Left Factor", LEFT_FACTOR_DEFAULT);
+    	double speed = SmartDashboard.getNumber("Speed", DRIVE_SPEED_DEFAULT);
+    	double time = SmartDashboard.getNumber("Time", DRIVE_TIME_DEFAULT);
+    	double turnFactor = SmartDashboard.getNumber("Time Factor", TIME_FACTOR_DEFAULT);
+    	double turnSpeed = SmartDashboard.getNumber("Turn Speed", TURN_SPEED_DEFAULT);
     	autonomousCommand = new AutoCommandGroup(frontBack, leftRight, visionReceiver,
-    			speed, time, turnFactor);
+    			speed, time, turnFactor, turnSpeed);
     	CancelCommand cancel = new CancelCommand(new Command[] { autonomousCommand });
     	sonarTrigger = new SonarTrigger(10, sonarReceiver, cancel);
     	sonarTrigger.start();
-        
+    	
 		/* String autoSelected = SmartDashboard.getString("Auto Selector", "Default");
 		switch(autoSelected) {
 		case "My Auto":
@@ -134,9 +143,9 @@ public class Robot extends IterativeRobot {
         // teleop starts running. If you want the autonomous to 
         // continue until interrupted by another command, remove
         // this line or comment it out.
-        if (autonomousCommand != null) autonomousCommand.cancel();
+        if (autonomousCommand != null) { autonomousCommand.cancel(); }
+        if (sonarTrigger != null) {	sonarTrigger.cancel(); }
         teleopCommand.start();
-        sonarTrigger.cancel();
     }
 
     /**
@@ -150,6 +159,6 @@ public class Robot extends IterativeRobot {
      * This function is called periodically during test mode
      */
     public void testPeriodic() {
-        LiveWindow.run();
+    	LiveWindow.run();
     }
 }

--- a/src/org/usfirst/frc/team1076/robot/commands/AutoCommandGroup.java
+++ b/src/org/usfirst/frc/team1076/robot/commands/AutoCommandGroup.java
@@ -1,0 +1,45 @@
+package org.usfirst.frc.team1076.robot.commands;
+
+import org.usfirst.frc.team1076.robot.subsystems.FrontBackMotors;
+import org.usfirst.frc.team1076.robot.subsystems.LeftRightMotors;
+import org.usfirst.frc.team1076.robot.vision.VisionReceiver;
+
+import edu.wpi.first.wpilibj.command.CommandGroup;
+
+/**
+ *
+ */
+public class AutoCommandGroup extends CommandGroup {
+	
+	/**
+	 * 
+	 * @param frontBack
+	 * @param leftRight
+	 * @param vision
+	 */
+	public AutoCommandGroup(FrontBackMotors frontBack, LeftRightMotors leftRight, VisionReceiver vision) {
+		this(frontBack, leftRight, vision, 0.5, 2, 1);
+	}
+	
+	/**
+	 * 
+	 * @param frontBack
+	 * @param leftRight
+	 * @param vision
+	 * @param speed
+	 * @param time
+	 * @param turnFactor
+	 */
+    public AutoCommandGroup(FrontBackMotors frontBack, LeftRightMotors leftRight, VisionReceiver vision,
+    		double speed, double time, double turnFactor) {
+    	DriveForwardBackward forward = new DriveForwardBackward(leftRight, speed, time);
+    	RotateWithVision rotate = new RotateWithVision(frontBack, leftRight, vision);
+    	rotate.timeFactor = turnFactor;
+    	// This is inelegant, but this should be enough to run for the 15 seconds of autonomous.
+    	for (int i = 0; i < 6; ++i) {
+    		addSequential(forward);
+    		addSequential(rotate);
+    	}
+    }
+	
+}

--- a/src/org/usfirst/frc/team1076/robot/commands/AutoCommandGroup.java
+++ b/src/org/usfirst/frc/team1076/robot/commands/AutoCommandGroup.java
@@ -18,7 +18,7 @@ public class AutoCommandGroup extends CommandGroup {
 	 * @param vision
 	 */
 	public AutoCommandGroup(FrontBackMotors frontBack, LeftRightMotors leftRight, VisionReceiver vision) {
-		this(frontBack, leftRight, vision, 0.5, 2, 1);
+		this(frontBack, leftRight, vision, 0.5, 2, 1, 0.3);
 	}
 	
 	/**
@@ -31,12 +31,13 @@ public class AutoCommandGroup extends CommandGroup {
 	 * @param turnFactor
 	 */
     public AutoCommandGroup(FrontBackMotors frontBack, LeftRightMotors leftRight, VisionReceiver vision,
-    		double speed, double time, double turnFactor) {
-    	DriveForwardBackward forward = new DriveForwardBackward(leftRight, speed, time);
-    	RotateWithVision rotate = new RotateWithVision(frontBack, leftRight, vision);
-    	rotate.timeFactor = turnFactor;
+    		double speed, double time, double turnFactor, double turnSpeed) {
     	// This is inelegant, but this should be enough to run for the 15 seconds of autonomous.
     	for (int i = 0; i < 6; ++i) {
+        	DriveForwardBackward forward = new DriveForwardBackward(leftRight, time, speed);
+        	RotateWithVision rotate = new RotateWithVision(frontBack, leftRight, vision);
+        	rotate.timeFactor = turnFactor;
+        	rotate.speed = turnSpeed;
     		addSequential(forward);
     		addSequential(rotate);
     	}

--- a/src/org/usfirst/frc/team1076/robot/commands/AutoCommandGroup.java
+++ b/src/org/usfirst/frc/team1076/robot/commands/AutoCommandGroup.java
@@ -33,7 +33,7 @@ public class AutoCommandGroup extends CommandGroup {
     public AutoCommandGroup(FrontBackMotors frontBack, LeftRightMotors leftRight, VisionReceiver vision,
     		double speed, double time, double turnFactor, double turnSpeed) {
     	// This is inelegant, but this should be enough to run for the 15 seconds of autonomous.
-    	for (int i = 0; i < 6; ++i) {
+    	for (int i = 0; i < 10; ++i) {
         	DriveForwardBackward forward = new DriveForwardBackward(leftRight, time, speed);
         	RotateWithVision rotate = new RotateWithVision(frontBack, leftRight, vision);
         	rotate.timeFactor = turnFactor;

--- a/src/org/usfirst/frc/team1076/robot/commands/RotateWithVision.java
+++ b/src/org/usfirst/frc/team1076/robot/commands/RotateWithVision.java
@@ -14,10 +14,12 @@ import edu.wpi.first.wpilibj.command.Command;
  */
 public class RotateWithVision extends Command {
     public double timeFactor = 1;
+    public double speed = 0.3;
 
     VisionReceiver receiver;
     FrontBackMotors frontBack;
     LeftRightMotors leftRight;
+    RotateCommand commandDelegate;
     
     public RotateWithVision(FrontBackMotors frontBack, LeftRightMotors leftRight, VisionReceiver receiver) {
         requires(frontBack);
@@ -34,34 +36,53 @@ public class RotateWithVision extends Command {
         VisionData data = receiver.getData();
         double heading = data.getHeading();
         VisionStatus status = data.getStatus();
-        double speed = 1;
-        double time = heading * timeFactor;
-
+        double time = Math.abs(heading * timeFactor);
+        
         if (status.equals(VisionStatus.ERROR) && data.getErrorCount() > 10) {
+        	System.out.println("Failed with " + data.getErrorCount() + " errors in a row.");
             return;
         }
 
         if (heading > 0) {
-            new RotateCommand(leftRight, frontBack, time, speed).start();
+            commandDelegate = new RotateCommand(leftRight, frontBack, time, speed);
         } else if (heading < 0) {
-            new RotateCommand(leftRight, frontBack, time, -speed).start();
+            commandDelegate = new RotateCommand(leftRight, frontBack, time, -speed);
+        }
+        
+        if (commandDelegate != null) {
+        	commandDelegate.initialize();
         }
     }
 
     // Called repeatedly when this Command is scheduled to run
-    protected void execute() { }
+    protected void execute() {
+    	if (commandDelegate != null) {
+    		commandDelegate.execute();
+    	}
+    }
 
     // Make this return true when this Command no longer needs to run execute()
     protected boolean isFinished() {
-        return true;
+    	if (commandDelegate != null) {
+    		return commandDelegate.isFinished();
+    	} else {
+    		return true;
+    	}
     }
 
     // Called once after isFinished returns true
-    protected void end() { }
+    protected void end() {
+    	System.out.println("End!");
+    	if (commandDelegate != null) {
+    		commandDelegate.end();
+    	}
+    }
 
     // Called when another command which requires one or more of the same
     // subsystems is scheduled to run
     protected void interrupted() {
-        end();
+    	if (commandDelegate != null) {
+    		commandDelegate.interrupted();
+    	}
     }
 }

--- a/src/org/usfirst/frc/team1076/robot/commands/TeleopCommand.java
+++ b/src/org/usfirst/frc/team1076/robot/commands/TeleopCommand.java
@@ -33,7 +33,7 @@ public class TeleopCommand extends Command {
     // Called repeatedly when this Command is scheduled to run
     protected void execute() {
     	final double x = gamepad.getAxis(GamepadAxis.LeftX);
-    	final double y = gamepad.getAxis(GamepadAxis.LeftY);
+    	final double y = -gamepad.getAxis(GamepadAxis.LeftY);
     	// Counterclockwise ends up positive.
     	final double rot = gamepad.getAxis(GamepadAxis.RightX);
     	
@@ -44,16 +44,16 @@ public class TeleopCommand extends Command {
     	// move at a speed proportional to their radius.
     	final double radiusScale = 14.5 / 23;
 
-    	// To rotate counterclockwise, we want the following modification:
-    	//   <
-    	// v   ^
+    	// To rotate clockwise, we want the following modification:
     	//   >
-    	// Which means that frontSpeed should be decreased, back increased,
-    	// left decreased, and right increased.
-    	final double front = x - rot * radiusScale;
-    	final double back = x + rot * radiusScale;
-    	final double left = y - rot;
-    	final double right = y + rot;
+    	// ^   v
+    	//   <
+    	// Which means that frontSpeed should be increased, back decreased,
+    	// left increased, and right decreased.
+    	final double front = x + rot * radiusScale;
+    	final double back = x - rot * radiusScale;
+    	final double left = y + rot;
+    	final double right = y - rot;
     	
     	// We don't want any motor to run faster than unit speed, so if anything
     	// is larger than the max speed we'll scale them down.
@@ -61,10 +61,10 @@ public class TeleopCommand extends Command {
     	// is 0.5, then we'll get 2.0 and divide by 2.0.
     	final double norm = selectMaxAbs(new double[] {1/maxSpeed, front, back, left, right});
     	
-    	frontBack.setFrontSpeed(-front / norm);
-    	frontBack.setBackSpeed(-back / norm);
-    	leftRight.setLeftSpeed(-left / norm);
-    	leftRight.setRightSpeed(-right / norm);
+    	frontBack.setFrontSpeed(front / norm);
+    	frontBack.setBackSpeed(back / norm);
+    	leftRight.setLeftSpeed(left / norm);
+    	leftRight.setRightSpeed(right / norm);
     }
     
     private double selectMaxAbs(double[] items) {

--- a/src/org/usfirst/frc/team1076/robot/subsystems/FrontBackMotors.java
+++ b/src/org/usfirst/frc/team1076/robot/subsystems/FrontBackMotors.java
@@ -28,7 +28,7 @@ public class FrontBackMotors extends Subsystem {
 	 */
 	public void setFrontSpeed(double speed) {
 		// Negative since the motor is reversed
-		this.frontMotor.set(-speed);
+		this.frontMotor.set(speed);
 	}
 
 	/**
@@ -36,7 +36,7 @@ public class FrontBackMotors extends Subsystem {
 	 * @param speed a number in the range -1 to 1 inclusive.
 	 */
 	public void setBackSpeed(double speed) {
-		this.backMotor.set(speed);
+		this.backMotor.set(-speed);
 	}
 
 	/**

--- a/src/org/usfirst/frc/team1076/robot/vision/VisionData.java
+++ b/src/org/usfirst/frc/team1076/robot/vision/VisionData.java
@@ -64,7 +64,8 @@ public class VisionData {
             }
             heading = json.getInt("heading");
             range = json.getDouble("range");
-        } catch (JSONException e) { 
+        } catch (JSONException e) {
+        	errorCount += 1;
             // Malformed JSON packet, assume no useful data
         }
     }

--- a/src/org/usfirst/frc/team1076/robot/vision/VisionReceiver.java
+++ b/src/org/usfirst/frc/team1076/robot/vision/VisionReceiver.java
@@ -36,11 +36,17 @@ public class VisionReceiver {
 	            return;
 	        }
 	        
+	        boolean foundPacket = false;
 	        while (true) {
 	            try {
 	                socket.receive(packet);
+	                System.out.println("Packet from " + packet.getAddress());
+	                foundPacket = true;
 	            } catch (SocketTimeoutException e) {
 	                // Exit once we have received all the packets.
+	            	if (!foundPacket) {
+	            		this.data.errorCount += 1;
+	            	}
 	                return;
 	            } catch (IOException e) {
 	                e.printStackTrace();


### PR DESCRIPTION
This PR adds a complete autonomous mode for the WAPUR bot. I think this should be merged in order to have a complete history of the WAPUR robot.

The autonomous mode consists of a forward command (dead reckoning style), then swapping between rotation using vision data and forward movement.