### PR TITLE
Update the robot to be compatible with 2017 WPILib

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -4,6 +4,10 @@
 	<classpathentry exported="true" kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry exported="true" kind="var" path="networktables" sourcepath="networktables.sources"/>
 	<classpathentry exported="true" kind="var" path="wpilib" sourcepath="wpilib.sources"/>
-	<classpathentry kind="lib" path="json.jar" sourcepath="json-sources.jar"/>
+	<classpathentry exported="true" kind="var" path="opencv" sourcepath="opencv.sources"/>
+	<classpathentry exported="true" kind="var" path="cscore" sourcepath="cscore.sources"/>
+	<classpathentry exported="true" kind="lib" path="json.jar"/>
+	<classpathentry kind="var" path="USERLIBS_DIR/CTRLib.jar"/>
+	<classpathentry kind="var" path="USERLIBS_DIR/json.jar" sourcepath="/USERLIBS_DIR/json-sources.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/src/org/usfirst/frc/team1076/robot/Robot.java
+++ b/src/org/usfirst/frc/team1076/robot/Robot.java
@@ -2,7 +2,6 @@
 package org.usfirst.frc.team1076.robot;
 
 import edu.wpi.first.wpilibj.Compressor;
-import edu.wpi.first.wpilibj.CANTalon;
 import edu.wpi.first.wpilibj.IterativeRobot;
 import edu.wpi.first.wpilibj.Solenoid;
 import edu.wpi.first.wpilibj.command.Command;
@@ -17,6 +16,8 @@ import org.usfirst.frc.team1076.robot.commands.TeleopCommand;
 import org.usfirst.frc.team1076.robot.subsystems.FrontBackMotors;
 import org.usfirst.frc.team1076.robot.subsystems.LeftRightMotors;
 import org.usfirst.frc.team1076.robot.vision.VisionReceiver;
+
+import com.ctre.CANTalon;
 
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;


### PR DESCRIPTION
In the new 2017 WPILib, all Talon motor related classes have been moved to an external userlibrary called "com.ctre". This commit changes the only instance of a CANTalon to be imported from the com.ctre library. The classpath has also been updated accordingly. In addition, the JSON library was also added to the WPILib user folder (and the classpath updated to reflect that. The old entry is still there for the time being)